### PR TITLE
Add multi-threading

### DIFF
--- a/Random-walk-edges-dodecahedron.jl
+++ b/Random-walk-edges-dodecahedron.jl
@@ -1,3 +1,6 @@
+import Base.Threads.@spawn
+# Make sure to run Julia with --threads NoOfThreads to enable multi-threading!
+
 legalMoves = [2 3 4
     1 5 7
     1 6 8
@@ -58,6 +61,12 @@ end
 noSimulations = 1_000_000
 
 # Run the function 10 times and print their averages.
+tasks = Task[]
 for j in 1:10
-    println(simulate(noSimulations, legalMoves))
+    push!(tasks, @spawn simulate(noSimulations, legalMoves)) # Run each simulation in a separate thread
+end
+
+# Print the result of each thread once it finishes running the simulation
+for t in tasks
+    println(fetch(t))
 end

--- a/Random-walk-edges-dodecahedron.jl
+++ b/Random-walk-edges-dodecahedron.jl
@@ -58,15 +58,17 @@ end
 
 
 # Specify the number of simulations for every function simulate call.
-noSimulations = 1_000_000
+noSimulations = 50_000_000
 
 # Run the function 10 times and print their averages.
 tasks = Task[]
-for j in 1:10
-    push!(tasks, @spawn simulate(noSimulations, legalMoves)) # Run each simulation in a separate thread
-end
+@time begin
+    for j in 1:16
+        push!(tasks, @spawn simulate(noSimulations, legalMoves)) # Run each simulation in a separate thread
+    end
 
-# Print the result of each thread once it finishes running the simulation
-for t in tasks
-    println(fetch(t))
+    # Print the result of each thread once it finishes running the simulation
+    for t in tasks
+        println(fetch(t))
+    end
 end


### PR DESCRIPTION
Run the simulations in parallel to improve performance on multi-core computers. 

Make sure to run Julia in multi-threading mode

- `--threads `_NoOfThreads_
- by setting `JULIA_NUM_THREADS` env var
- by changing settings in VSCode